### PR TITLE
add aria-label to 'x' icon button

### DIFF
--- a/src/components/m-table-action.js
+++ b/src/components/m-table-action.js
@@ -51,6 +51,7 @@ class MTableAction extends React.Component {
         size={this.props.size}
         color="inherit"
         disabled={disabled}
+        aria-label="Clear"
         onClick={handleOnClick}
       >
         {icon}


### PR DESCRIPTION
## Related Issue

#1884

## Description

Add an `aria-label` of _clear_ to the 'x' icon button in the search field for accessibility.

## Impacted Areas in Application

Affects no components, only affects a screen reader's announcement of the 'x' button.

